### PR TITLE
rcube_addresses.php syntax error

### DIFF
--- a/program/lib/Roundcube/rcube_addresses.php
+++ b/program/lib/Roundcube/rcube_addresses.php
@@ -101,7 +101,7 @@ class rcube_addresses extends rcube_contacts
             $start_row,
             $length,
             $this->user_id,
-            $this->type,
+            $this->type
         );
 
         while ($sql_result && ($sql_arr = $this->db->fetch_assoc($sql_result))) {


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected ')' in /var/www/html/https_root/roundcubemail-1.4.9/program/lib/Roundcube/rcube_addresses.php on line 105